### PR TITLE
:sparkles: feat: Add nickname field to User and include it in JWT

### DIFF
--- a/src/main/java/org/example/expert/config/AuthUserArgumentResolver.java
+++ b/src/main/java/org/example/expert/config/AuthUserArgumentResolver.java
@@ -36,11 +36,12 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
     ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
-        // JwtFilter 에서 set 한 userId, email, userRole 값을 가져옴
+        // JwtFilter 에서 set 한 userId, email,nickname, userRole 값을 가져옴
         Long userId = (Long) request.getAttribute("userId");
         String email = (String) request.getAttribute("email");
+        String nickname = (String) request.getAttribute("nickname");
         UserRole userRole = UserRole.of((String) request.getAttribute("userRole"));
 
-        return new AuthUser(userId, email, userRole);
+        return new AuthUser(userId, email, nickname, userRole);
     }
 }

--- a/src/main/java/org/example/expert/config/JwtFilter.java
+++ b/src/main/java/org/example/expert/config/JwtFilter.java
@@ -59,6 +59,8 @@ public class JwtFilter implements Filter {
 
             httpRequest.setAttribute("userId", Long.parseLong(claims.getSubject()));
             httpRequest.setAttribute("email", claims.get("email"));
+            // 닉네임 추가(프론트에서 꺼낼 수 있음)
+            httpRequest.setAttribute("nickname", claims.get("nickname"));
             httpRequest.setAttribute("userRole", claims.get("userRole"));
 
             if (url.startsWith("/admin")) {

--- a/src/main/java/org/example/expert/config/JwtUtil.java
+++ b/src/main/java/org/example/expert/config/JwtUtil.java
@@ -34,13 +34,14 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(Long userId, String email, UserRole userRole) {
+    public String createToken(Long userId, String email, String nickname, UserRole userRole) {
         Date date = new Date();
 
         return BEARER_PREFIX +
                 Jwts.builder()
                         .setSubject(String.valueOf(userId))
                         .claim("email", email)
+                        .claim("nickname", nickname)
                         .claim("userRole", userRole)
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))
                         .setIssuedAt(date) // 발급일

--- a/src/main/java/org/example/expert/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/org/example/expert/domain/auth/dto/request/SignupRequest.java
@@ -14,6 +14,8 @@ public class SignupRequest {
     @NotBlank @Email
     private String email;
     @NotBlank
+    private String nickname;
+    @NotBlank
     private String password;
     @NotBlank
     private String userRole;

--- a/src/main/java/org/example/expert/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/expert/domain/auth/service/AuthService.java
@@ -37,12 +37,14 @@ public class AuthService {
 
         User newUser = new User(
                 signupRequest.getEmail(),
+                signupRequest.getNickname(),
                 encodedPassword,
                 userRole
         );
         User savedUser = userRepository.save(newUser);
 
-        String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), userRole);
+        String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), savedUser.getNickname(),
+                userRole);
 
         return new SignupResponse(bearerToken);
     }
@@ -56,7 +58,7 @@ public class AuthService {
             throw new AuthException("잘못된 비밀번호입니다.");
         }
 
-        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getUserRole());
+        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getNickname(), user.getUserRole());
 
         return new SigninResponse(bearerToken);
     }

--- a/src/main/java/org/example/expert/domain/common/dto/AuthUser.java
+++ b/src/main/java/org/example/expert/domain/common/dto/AuthUser.java
@@ -8,11 +8,13 @@ public class AuthUser {
 
     private final Long id;
     private final String email;
+    private final String nickname;
     private final UserRole userRole;
 
-    public AuthUser(Long id, String email, UserRole userRole) {
+    public AuthUser(Long id, String email, String nickname, UserRole userRole) {
         this.id = id;
         this.email = email;
+        this.nickname = nickname;
         this.userRole = userRole;
     }
 }

--- a/src/main/java/org/example/expert/domain/user/entity/User.java
+++ b/src/main/java/org/example/expert/domain/user/entity/User.java
@@ -13,28 +13,34 @@ import org.example.expert.domain.user.enums.UserRole;
 @Table(name = "users")
 public class User extends Timestamped {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column(unique = true)
     private String email;
+    private String nickname;
     private String password;
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
-    public User(String email, String password, UserRole userRole) {
+    public User(String email, String nickname, String password, UserRole userRole) {
         this.email = email;
+        this.nickname = nickname;
         this.password = password;
         this.userRole = userRole;
     }
 
-    private User(Long id, String email, UserRole userRole) {
+    private User(Long id, String nickname, String email, UserRole userRole) {
         this.id = id;
         this.email = email;
+        this.nickname = nickname;
         this.userRole = userRole;
     }
 
     public static User fromAuthUser(AuthUser authUser) {
-        return new User(authUser.getId(), authUser.getEmail(), authUser.getUserRole());
+        return new User(
+                authUser.getId(), authUser.getEmail(),
+                authUser.getNickname(), authUser.getUserRole());
     }
 
     public void changePassword(String password) {


### PR DESCRIPTION
## 2. 코드 추가 퀴즈 - JWT의 이해 🔍
### 변경된 요구사항
- User정보에 nickname이 필요해짐.
-  JWT에서 유저의 닉네임을 꺼내 사용해야함.

### 해결 방법
#### users테이블에 nickname컬럼 추가
- User클래스에서 nickname필드 추가 후 생성자도 nickname을 넣어 수정

#### 회원가입 시 사용자에게 닉네임 정보를 함께 받아 회원가입
- SignupRequest에 nickname필드를 추가

#### 토큰 발급을 로직 수정
- JwtUtil클래스에서 createToken 메서드에 인자값으로 닉네임을 받고, 클레임에 닉네임을 추가해줌.

#### 회원가입 로직 수정
- User객체 생성시 SignupRequest에서 닉네임을 꺼내 생성자에 함께 넣어 User객체 생성
-  회원가입 토큰발급을 위해 createToken에 유저정보 닉네임과 함께 넣어줌.

#### 로그인 로직 수정
- 토큰생성 로직 수정됨에 따라 로그인 시 로그인 토큰 발급에 필요한  정보를 수정 해줌.(닉네임 추가)

#### 클라이언트에게 유저의 정보를 넘기기(토큰)
- JwtFilter클래스에서  유효한 토큰일 경우 토큰의 클레임에서 닉네임정보를 꺼내 setAttribute해줌
- AuthUserArgumentResolver에서 resolveArgument로 getAttribute하여 필요한 정보(닉네임)을 꺼내 반환해줌.