### PR TITLE
:recycle: refactor: 일정조회 필터링 기능 추가

### DIFF
--- a/src/main/java/org/example/expert/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/example/expert/domain/todo/controller/TodoController.java
@@ -29,9 +29,12 @@ public class TodoController {
     @GetMapping("/todos")
     public ResponseEntity<Page<TodoResponse>> getTodos(
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String weather,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate
     ) {
-        return ResponseEntity.ok(todoService.getTodos(page, size));
+        return ResponseEntity.ok(todoService.getTodos(page, size,weather,startDate,endDate));
     }
 
     @GetMapping("/todos/{todoId}")

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
@@ -7,12 +7,22 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
-    @Query("SELECT t FROM Todo t LEFT JOIN FETCH t.user u ORDER BY t.modifiedAt DESC")
-    Page<Todo> findAllByOrderByModifiedAtDesc(Pageable pageable);
+    @Query("SELECT t FROM Todo t " +
+            "LEFT JOIN FETCH t.user u " +
+            "WHERE (:weather IS NULL OR t.weather LIKE :weather) " +
+            "AND (t.modifiedAt BETWEEN :startDate AND :endDate) " +
+            "ORDER BY t.modifiedAt DESC")
+    Page<Todo> findTodosByFiltersOrderByModifiedAtDesc(
+            Pageable pageable,
+            @Param("weather") String weather,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
 
     @Query("SELECT t FROM Todo t " +
             "LEFT JOIN t.user " +

--- a/src/main/java/org/example/expert/domain/todo/service/TodoService.java
+++ b/src/main/java/org/example/expert/domain/todo/service/TodoService.java
@@ -17,6 +17,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -48,10 +51,17 @@ public class TodoService {
     }
 
     @Transactional(readOnly = true)
-    public Page<TodoResponse> getTodos(int page, int size) {
+    public Page<TodoResponse> getTodos(int page, int size, String weather,String startDate, String endDate) {
         Pageable pageable = PageRequest.of(page - 1, size);
+        LocalDateTime mysqlMinDate = LocalDateTime.parse("1000-01-01T00:00:00");
+        LocalDateTime mysqlMaxDate = LocalDateTime.parse("9999-12-31T23:59:59");
 
-        Page<Todo> todos = todoRepository.findAllByOrderByModifiedAtDesc(pageable);
+        LocalDateTime start = startDate==null ? mysqlMinDate : LocalDate.parse(startDate).atStartOfDay();
+        LocalDateTime end = endDate==null ? mysqlMaxDate : LocalDate.parse(endDate).atTime(23, 59, 59);
+
+
+
+        Page<Todo> todos = todoRepository.findTodosByFiltersOrderByModifiedAtDesc(pageable,weather,start,end);
 
         return todos.map(todo -> new TodoResponse(
                 todo.getId(),


### PR DESCRIPTION
## 5. 코드 개선 퀴즈 -  JPA의 이해
### 요구 사항 ➕
-  기존 일정 전체 조회에서 날씨와, 수정일을 기준으로 기간 검색 
---
### 해결 방법
- TodoController 컨트롤러 수정(날씨와 기간을 입력 받도록 수정)
``` 조건 : 날씨, 기간의 시작과 끝 파라미터는 필수 입력이 아님.```
```java
@RequestParam(required = false) String weather,
@RequestParam(required = false) String startDate,
@RequestParam(required = false) String endDate
```
를 추가해 입력값이 필수가 아닌 파라미터를 받는다. 그 후 서비스에 값들을 넘긴다. (입력값이 없다면 null)
```java
todoService.getTodos(page, size,weather,startDate,endDate)
```
- TodoService 서비스수정(날짜 형변환 및 기본값 초기화 후 repository로 넘김)
기간의 시작 과 끝 중 어느 하나라도 null이면 최소 최대의 기본값을 설정
```(이걸 적으면서 생각해보니 컨트롤러에서  @RequestParam(defaultValue=..)로 하면 될껄... 라고 늦은 후회)```

```java

LocalDateTime mysqlMinDate = LocalDateTime.parse("1000-01-01T00:00:00");
LocalDateTime mysqlMaxDate = LocalDateTime.parse("9999-12-31T23:59:59");

LocalDateTime start = startDate==null ? mysqlMinDate : LocalDate.parse(startDate).atStartOfDay();
LocalDateTime end = endDate==null ? mysqlMaxDate : LocalDate.parse(endDate).atTime(23, 59, 59);
```
null이면 mysql의 날짜 최소 최대값으로 초기화 아니면 입력값을 LocalDateTime형식으로 형변환
그 후 모든 값들을 repository에 넘긴다 
```java
Page<Todo> todos = todoRepository.findTodosByFiltersOrderByModifiedAtDesc(pageable,weather,start,end);
```
- TodoRepository 수정(쿼리문 수정)
날씨는 null이 넘어올 수 있기 때문에 null이면 전체 날씨 아니면 해당 날씨 기준으로 조회,  
날짜는 service에서 기본값을 설정해줬기 때문에 null은 안넘어옴, 수정일 기준으로 해당 기간 내에 데이터 조회 하도록 변경
```java
 @Query("SELECT t FROM Todo t " +
            "LEFT JOIN FETCH t.user u " +
            "WHERE (:weather IS NULL OR t.weather LIKE :weather) " +
            "AND (t.modifiedAt BETWEEN :startDate AND :endDate) " +
            "ORDER BY t.modifiedAt DESC")
    Page<Todo> findTodosByFiltersOrderByModifiedAtDesc(
            Pageable pageable,
            @Param("weather") String weather,
            @Param("startDate") LocalDateTime startDate,
            @Param("endDate") LocalDateTime endDate
    );
```
```메소드명도 조금 더 어울리게 변경하였다.```
