### PR TITLE
:bug: fix: 일정추가시 매니저추가

### DIFF
--- a/src/main/java/org/example/expert/domain/todo/entity/Todo.java
+++ b/src/main/java/org/example/expert/domain/todo/entity/Todo.java
@@ -30,7 +30,7 @@ public class Todo extends Timestamped {
     @OneToMany(mappedBy = "todo", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "todo")
+    @OneToMany(mappedBy = "todo", cascade = CascadeType.PERSIST)
     private List<Manager> managers = new ArrayList<>();
 
     public Todo(String title, String contents, String weather, User user) {


### PR DESCRIPTION
## 6. JPA Cascade
### 문제 원인🐛
- 일정 추가 시 매니저도 같이 추가 되도록 해야함.

### 해결 방법
- cascade를 추가하여 부모 엔티티를 저장할 때 연관된 엔티티도 저장되도록 한다.
```부모 엔티티 삭제 시 연관된 데이터도 삭제 되도록 하려면 CascadeType.ALL를 사용하는게 좋을 것같다```
```java
cascade = CascadeType.PERSIST
```
### Cascade 설정 종류
CascadeType.PERSIST: 부모 엔티티를 저장할 때 연관된 엔티티도 저장.
CascadeType.MERGE: 부모 엔티티를 병합(업데이트)할 때 연관된 엔티티도 병합.
CascadeType.REMOVE: 부모 엔티티를 삭제할 때 연관된 엔티티도 삭제.
CascadeType.ALL: 위 모든 작업(PERSIST, MERGE, REMOVE 등)을 전파.