### PR TITLE
:bug: fix: 댓글 전체 조회 시 N+1문제 해결

### DIFF
--- a/src/main/java/org/example/expert/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/expert/domain/comment/repository/CommentRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("SELECT c FROM Comment c JOIN c.user WHERE c.todo.id = :todoId")
+    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.todo.id = :todoId")
     List<Comment> findByTodoIdWithUser(@Param("todoId") Long todoId);
 }


### PR DESCRIPTION
## 7. N+1
### 문제 원인🐛
- 댓글 전체 조회 시 N+1문제 발생
- 원인 CommentRepository에서 댓글전체 조회하는 findByTodoIdWithUser매서드의 쿼리에서 단순 JOIN하고 있기 때문
### 해결 방법
- JOIN FETCH로 바꿔 데이터를 한꺼면에 가져올 수 있도록 수정해주면된다.
```java
@Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.todo.id = :todoId")
```
