### PR TITLE
:recycle: refactor: Spring Security적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // QueryDSL 추가
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/org/example/expert/config/FilterConfig.java
+++ b/src/main/java/org/example/expert/config/FilterConfig.java
@@ -8,15 +8,16 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 public class FilterConfig {
+    // 스프링 시큐리티가 있으므로 해당 클래스는 필요가 없음
 
-    private final JwtUtil jwtUtil;
-
-    @Bean
-    public FilterRegistrationBean<JwtFilter> jwtFilter() {
-        FilterRegistrationBean<JwtFilter> registrationBean = new FilterRegistrationBean<>();
-        registrationBean.setFilter(new JwtFilter(jwtUtil));
-        registrationBean.addUrlPatterns("/*"); // 필터를 적용할 URL 패턴을 지정합니다.
-
-        return registrationBean;
-    }
+//    private final JwtUtil jwtUtil;
+//
+//    @Bean
+//    public FilterRegistrationBean<JwtFilter> jwtFilter() {
+//        FilterRegistrationBean<JwtFilter> registrationBean = new FilterRegistrationBean<>();
+//        registrationBean.setFilter(new JwtFilter(jwtUtil));
+//        registrationBean.addUrlPatterns("/*"); // 필터를 적용할 URL 패턴을 지정합니다.
+//
+//        return registrationBean;
+//    }
 }

--- a/src/main/java/org/example/expert/config/JwtUtil.java
+++ b/src/main/java/org/example/expert/config/JwtUtil.java
@@ -42,7 +42,7 @@ public class JwtUtil {
                         .setSubject(String.valueOf(userId))
                         .claim("email", email)
                         .claim("nickname", nickname)
-                        .claim("userRole", userRole)
+                        .claim("userRole", userRole.name())
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))
                         .setIssuedAt(date) // 발급일
                         .signWith(key, signatureAlgorithm) // 암호화 알고리즘

--- a/src/main/java/org/example/expert/config/SecurityConfig.java
+++ b/src/main/java/org/example/expert/config/SecurityConfig.java
@@ -23,11 +23,6 @@ public class SecurityConfig {
     private final JwtFilter jwtFilter;
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
-    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)  // .csrf().disable() 방식은 더 이상 사용 안함.

--- a/src/main/java/org/example/expert/config/SecurityConfig.java
+++ b/src/main/java/org/example/expert/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package org.example.expert.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
+
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)  // .csrf().disable() 방식은 더 이상 사용 안함.
+                .httpBasic(AbstractHttpConfigurer::disable) // BasicAuthenticationFilter 비활성화
+                .formLogin(AbstractHttpConfigurer::disable) // UsernamePasswordAuthenticationFilter,
+                // DefaultLoginPageGeneratingFilter 비활성화
+                .addFilterBefore(jwtFilter, SecurityContextHolderAwareRequestFilter.class)
+                .authorizeHttpRequests(auth -> auth
+                                .requestMatchers("/*","/auth").permitAll()
+                                .requestMatchers("/admin/**").hasRole("ADMIN")
+                                .anyRequest().authenticated()
+                )
+                .exceptionHandling(exceptions -> exceptions
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            response.sendError(HttpServletResponse.SC_FORBIDDEN, "관리자 권한이 없습니다.");
+                        })
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/example/expert/domain/comment/controller/CommentController.java
+++ b/src/main/java/org/example/expert/domain/comment/controller/CommentController.java
@@ -9,6 +9,7 @@ import org.example.expert.domain.comment.service.CommentService;
 import org.example.expert.domain.common.annotation.Auth;
 import org.example.expert.domain.common.dto.AuthUser;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,7 +22,7 @@ public class CommentController {
 
     @PostMapping("/todos/{todoId}/comments")
     public ResponseEntity<CommentSaveResponse> saveComment(
-            @Auth AuthUser authUser,
+            @AuthenticationPrincipal AuthUser authUser,
             @PathVariable long todoId,
             @Valid @RequestBody CommentSaveRequest commentSaveRequest
     ) {

--- a/src/main/java/org/example/expert/domain/common/dto/AuthUser.java
+++ b/src/main/java/org/example/expert/domain/common/dto/AuthUser.java
@@ -2,9 +2,14 @@ package org.example.expert.domain.common.dto;
 
 import lombok.Getter;
 import org.example.expert.domain.user.enums.UserRole;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
 
 @Getter
-public class AuthUser {
+public class AuthUser implements UserDetails {
 
     private final Long id;
     private final String email;
@@ -16,5 +21,20 @@ public class AuthUser {
         this.email = email;
         this.nickname = nickname;
         this.userRole = userRole;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(userRole::getRole);
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email;
     }
 }

--- a/src/main/java/org/example/expert/domain/manager/controller/ManagerController.java
+++ b/src/main/java/org/example/expert/domain/manager/controller/ManagerController.java
@@ -9,6 +9,7 @@ import org.example.expert.domain.manager.dto.response.ManagerResponse;
 import org.example.expert.domain.manager.dto.response.ManagerSaveResponse;
 import org.example.expert.domain.manager.service.ManagerService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,7 +22,7 @@ public class ManagerController {
 
     @PostMapping("/todos/{todoId}/managers")
     public ResponseEntity<ManagerSaveResponse> saveManager(
-            @Auth AuthUser authUser,
+            @AuthenticationPrincipal AuthUser authUser,
             @PathVariable long todoId,
             @Valid @RequestBody ManagerSaveRequest managerSaveRequest
     ) {
@@ -35,7 +36,7 @@ public class ManagerController {
 
     @DeleteMapping("/todos/{todoId}/managers/{managerId}")
     public void deleteManager(
-            @Auth AuthUser authUser,
+            @AuthenticationPrincipal AuthUser authUser,
             @PathVariable long todoId,
             @PathVariable long managerId
     ) {

--- a/src/main/java/org/example/expert/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/example/expert/domain/todo/controller/TodoController.java
@@ -10,6 +10,7 @@ import org.example.expert.domain.todo.dto.response.TodoSaveResponse;
 import org.example.expert.domain.todo.service.TodoService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,7 +21,7 @@ public class TodoController {
 
     @PostMapping("/todos")
     public ResponseEntity<TodoSaveResponse> saveTodo(
-            @Auth AuthUser authUser,
+            @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody TodoSaveRequest todoSaveRequest
     ) {
         return ResponseEntity.ok(todoService.saveTodo(authUser, todoSaveRequest));
@@ -34,7 +35,7 @@ public class TodoController {
             @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate
     ) {
-        return ResponseEntity.ok(todoService.getTodos(page, size,weather,startDate,endDate));
+        return ResponseEntity.ok(todoService.getTodos(page, size, weather, startDate, endDate));
     }
 
     @GetMapping("/todos/{todoId}")

--- a/src/main/java/org/example/expert/domain/user/controller/UserAdminController.java
+++ b/src/main/java/org/example/expert/domain/user/controller/UserAdminController.java
@@ -1,6 +1,7 @@
 package org.example.expert.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.common.annotation.Auth;
 import org.example.expert.domain.user.dto.request.UserRoleChangeRequest;
 import org.example.expert.domain.user.service.UserAdminService;
 import org.springframework.web.bind.annotation.PatchMapping;

--- a/src/main/java/org/example/expert/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/expert/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import org.example.expert.domain.user.dto.request.UserChangePasswordRequest;
 import org.example.expert.domain.user.dto.response.UserResponse;
 import org.example.expert.domain.user.service.UserService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,7 +22,8 @@ public class UserController {
     }
 
     @PutMapping("/users")
-    public void changePassword(@Auth AuthUser authUser, @RequestBody UserChangePasswordRequest userChangePasswordRequest) {
+    public void changePassword(@AuthenticationPrincipal AuthUser authUser,
+                               @RequestBody UserChangePasswordRequest userChangePasswordRequest) {
         userService.changePassword(authUser.getId(), userChangePasswordRequest);
     }
 }

--- a/src/main/java/org/example/expert/domain/user/enums/UserRole.java
+++ b/src/main/java/org/example/expert/domain/user/enums/UserRole.java
@@ -1,11 +1,18 @@
 package org.example.expert.domain.user.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.example.expert.domain.common.exception.InvalidRequestException;
 
 import java.util.Arrays;
-
+@Getter
+@RequiredArgsConstructor
 public enum UserRole {
-    ADMIN, USER;
+    USER("ROLE_USER", "사용자 권한"),
+    ADMIN("ROLE_ADMIN", "관리자 권한");
+
+    private final String role;        // Spring Security 권한 이름
+    private final String description; // 권한 설명
 
     public static UserRole of(String role) {
         return Arrays.stream(UserRole.values())


### PR DESCRIPTION
## 9. Spring Security
### 요구 사항🐛
- 프로젝트에 Spring Security 적용하기
- 기존 Filter와 Argument Resolver를 사용하던 코드들을 Spring Security로 변경하
- 토큰 기반 인증 방식은 유지할 거예요. JWT는 그대로 사용

### 구현 과정
#### 먼저  Spring Security를 사용하기위해 build.gradle 관련 의존성 추가해주기!
```gradle
implementation 'org.springframework.boot:spring-boot-starter-security'
```
크게 수정할 부분은 JwtFillter이고, SecurityConfig파일을 추가해준다.
그 후 AuthUser클래스를 스프링 시큐리티에서 사용할 수 있도록 수정해준다.   

```java

@Getter
public class AuthUser implements UserDetails {

    private final Long id;
              :
    public AuthUser(Long id, String email, String nickname, UserRole userRole) {
       :
    }

    @Override
    public Collection<? extends GrantedAuthority> getAuthorities() {
        return Collections.singletonList(userRole::getRole);
    }

    @Override
    public String getPassword() {
        return "";
    }

    @Override
    public String getUsername() {
        return this.email;
    }

```
기존 AuthUser를 시큐리티에서 사용하기 위해 UserDetails 를 임플리먼츠 해준후 필요한 메소드를 오버라이딩 해준다.
JwtFilter에서는 토큰의 유효성 검사만 한 후 토큰에서 유저정보를 꺼내 시큐리티에 유저 정보를 넘긴다!
```java
Long userId =  Long.parseLong(claims.getSubject());
            UserRole userRole = UserRole.valueOf(claims.get("userRole", String.class));
            String userEmail = (String) claims.get("email");
            String userNickName = (String) claims.get("nickname");

            UserDetails authUser = new AuthUser(userId,userEmail,userNickName,userRole);
            SecurityContextHolder
                    .getContext()
                    .setAuthentication(
                            new UsernamePasswordAuthenticationToken(
                                    authUser, null, authUser.getAuthorities()));

```
```기존 JwtFilter에서 url검증 부분 지우고, Argument Resolver에 값을 넘겨주는 부분을 지워줌```
시큐리티에서는 JwtFilter에서 받은 유저 정보를 url검증과 권한 인증인가를 실시한다.
```java
 @Bean
    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
        return http
                .csrf(AbstractHttpConfigurer::disable)  // .csrf().disable() 방식은 더 이상 사용 안함.
                .httpBasic(AbstractHttpConfigurer::disable) // BasicAuthenticationFilter 비활성화
                .formLogin(AbstractHttpConfigurer::disable) // UsernamePasswordAuthenticationFilter,
                // DefaultLoginPageGeneratingFilter 비활성화
                .addFilterBefore(jwtFilter, SecurityContextHolderAwareRequestFilter.class)
                .authorizeHttpRequests(auth -> auth
                                .requestMatchers("/*","/auth").permitAll()
                                .requestMatchers("/admin/**").hasRole("ADMIN")
                                .anyRequest().authenticated()
                )
                .exceptionHandling(exceptions -> exceptions
                        .accessDeniedHandler((request, response, accessDeniedException) -> {
                            response.sendError(HttpServletResponse.SC_FORBIDDEN, "관리자 권한이 없습니다.");
                        })
                )
                .build();
    }
```
컨트롤러에서는 @Auth로 유저정보를 가져오던 부분을 @AuthenticationPrincipal로 받아와 사용할 수 있다.

생각해보니 @Auth 어노테이션을 만들었는데 안쓰게 되니 AuthenticationPrincipal를 @Auth에서 작동되게 할 수 있지 않나 싶다..
(컨트롤러 하나하나 AuthenticationPrincipal로 바꿔줌)
